### PR TITLE
Pin numpy version to 2.3.5 in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ USER $NB_USER
 WORKDIR $HOME
 
 # Install workshop deps
-RUN mamba install -c acellera -c conda-forge ambertools htmd matplotlib mdtraj nglview numpy -y
+RUN mamba install -c acellera -c conda-forge ambertools htmd matplotlib mdtraj nglview numpy=2.3.5 -y
 
 # Get workshop files and move them to jovyan directory.
 COPY --chown=1000:100 . .


### PR DESCRIPTION
Numpy have deprecated certain features causing htmd to fail to do certain tasks. Pinning until it is fixed upstream.